### PR TITLE
Support setlist.fm API v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+beetsplug/__pycache__/*.pyc

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -109,6 +109,7 @@ requests_session = requests.Session()
 requests_session.headers = {'User-Agent': 'beets'}
 SETLISTFM_ENDPOINT = 'http://api.setlist.fm/rest/0.1/search/setlists.json'
 
+# todo: setlist.fm API is now at version 1.0; no useable response from old endpoint
 
 def _get_setlist(artist_name, date=None):
     """Query setlist.fm for an artist and return the first
@@ -124,7 +125,7 @@ def _get_setlist(artist_name, date=None):
                'date': date,
                })
 
-    if not response.status_code == 200:
+    if not response.status_code == 200: 
         return
 
     # Setlist.fm can have some events with empty setlists
@@ -143,6 +144,8 @@ def _get_setlist(artist_name, date=None):
                 for song in subset['song']:
                     track_names += [song['@name']]
             break  # Stop because we have found a setlist
+            
+    # todo: querying old API endpoint shows up as 'not found'; not transparent, response for unsuccessful query is probably distinguishable from errors
 
     return {'artist_name': artist_name,
             'venue_name': venue_name,

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -102,7 +102,7 @@ def _save_playlist(m3u_path, items):
     mkdirall(m3u_path)
     with open(syspath(m3u_path), 'w') as f:
         for item in items:
-            f.write(item.path.decode('unicode_escape') + u'\n')
+            f.write(item.path.decode('utf-8') + u'\n')
 
 
 
@@ -221,7 +221,7 @@ class SetlisterPlugin(BeetsPlugin):
                                 setlist_name + '.m3u'))
 
         _save_playlist(m3u_path, items)
-        self._log.info(u'Saved playlist at "{0}"'.format(m3u_path.decode('unicode_escape')))
+        self._log.info(u'Saved playlist at "{0}"'.format(m3u_path.decode('utf-8')))
 
     def find_items_in_lib(self, lib, track_names, artist_name):
         """Returns a list of items found, and list of items not found in library

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -102,7 +102,7 @@ def _save_playlist(m3u_path, items):
     mkdirall(m3u_path)
     with open(syspath(m3u_path), 'w') as f:
         for item in items:
-            f.write(item.path + b'\n')
+            f.write(item.path.decode('unicode_escape') + u'\n')
 
 
 
@@ -157,12 +157,12 @@ class SetlisterPlugin(BeetsPlugin):
         super(SetlisterPlugin, self).__init__()
         self.config.add({
             'playlist_dir': None,
-            'api_key': '***REMOVED***',
+            'api_key': '',
         })
 
         self.session = requests.Session()
         self.session.headers = {
-            'Accept': 'applicatiton/json',
+            'Accept': 'application/json',
             'User-Agent': 'beets',
             'x-api-key': self.config['api_key'].get(str)
         }
@@ -171,12 +171,13 @@ class SetlisterPlugin(BeetsPlugin):
         """Glue everything together
         """
 
-        if not self.config['playlist_dir']:
-            self._log.warning(u'You have to configure a playlist_dir')
+        if not os.path.isdir(os.path.expanduser(str(self.config['playlist_dir']))):
+            self._log.warning(u'You have to configure a valid `playlist_dir`')
             return
 
         if not self.config['api_key']:
-            self._log.warning(u'You have to provide you setlist.fm API key (https://www.setlist.fm/settings/apps)')
+            self._log.warning(u'You have to provide your setlist.fm API key. Request a key at https://www.setlist.fm/settings/apps and configure it as `api_key` as `api_key`')
+            return
 
         # todo: isn't it more sensible to have the checks above in SetlisterPlugin.__init__?
 
@@ -218,6 +219,7 @@ class SetlisterPlugin(BeetsPlugin):
         m3u_path = normpath(os.path.join(
                                 self.config['playlist_dir'].as_filename(),
                                 setlist_name + '.m3u'))
+
         _save_playlist(m3u_path, items)
         self._log.info(u'Saved playlist at "{0}"'.format(m3u_path))
 

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -27,6 +27,8 @@ import beets.autotag.hooks as hooks
 import os
 import requests
 
+import subprocess
+
 
 def _get_best_match(items, track_name, artist_name):
     """ Returns the best match (according to a track_name/artist_name distance)
@@ -172,7 +174,7 @@ class SetlisterPlugin(BeetsPlugin):
             'x-api-key': self.config['api_key'].get(str)
         }
 
-    def setlister(self, lib, artist_name, date=None):
+    def setlister(self, lib, artist_name, date=None, play=False):
         """Glue everything together
         """
 
@@ -218,6 +220,10 @@ class SetlisterPlugin(BeetsPlugin):
         _save_playlist(m3u_path, items)
         self._log.info(u'Saved playlist at "{0}"'.format(m3u_path.decode('utf-8')))
 
+        if play:
+            # todo: Double check whether this is sensible ~ beets documentation (it probably isn't)
+            subprocess.Popen(['xdg-open', m3u_path.decode('utf-8')])
+
     def find_items_in_lib(self, lib, track_names, artist_name):
         """Returns a list of items found, and list of items not found in library
         from a given list of track names.
@@ -237,7 +243,7 @@ class SetlisterPlugin(BeetsPlugin):
 
     def commands(self):
         def func(lib, opts, args):
-            self.setlister(lib, ui.decargs(args), opts.date)
+            self.setlister(lib, ui.decargs(args), opts.date, opts.play)
 
         cmd = ui.Subcommand(
             'setlister',
@@ -245,6 +251,8 @@ class SetlisterPlugin(BeetsPlugin):
         )
         cmd.parser.add_option('-d', '--date', dest='date', default=None,
                               help='setlist of a specific date (dd-MM-yyyy)')
+        cmd.parser.add_option('-p', '--play', action='store_true',
+                              help='play the playlist (boolean)')
 
         cmd.func = func
 

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -70,13 +70,17 @@ def _find_item_in_lib(lib, track_name, artist_name):
     lib with that.
     """
 
-    # todo: sometimes returns matches by other artists when requested artist has no matching tracks
+    # todo: sometimes returns matches by other artists when requested artist
+    # has no matching tracks
 
     # Query the library based on the track name
     query = MatchQuery('title', track_name)
     lib_results = lib._fetch(Item, query=query)
 
-    # Maybe the provided track name isn't all too good  todo: fails e.g. for Opeth - Reverie/Harlequin Forest due to mismatch in `/`
+    # Maybe the provided track name isn't all too good
+    # todo: fails e.g. for Opeth - Reverie/Harlequin Forest
+    #  due to mismatch in `/`
+
     # Search for the track on MusicBrainz, and use that info to retry our lib
     if not lib_results:
         mb_candidate = _get_mb_candidate(track_name, artist_name)
@@ -161,12 +165,20 @@ class SetlisterPlugin(BeetsPlugin):
             'api_key': '',
         })
 
-        if not os.path.isdir(os.path.expanduser(self.config['playlist_dir'].get(str))):
+        if not os.path.isdir(
+                os.path.expanduser(
+                    self.config['playlist_dir'].get(str)
+                )
+        ):
             self._log.warning(u'You have to configure a valid `playlist_dir`')
             return
 
         if not self.config['api_key']:
-            self._log.warning(u'You have to provide your setlist.fm API key. Request a key at https://www.setlist.fm/settings/apps and configure it as `api_key` as `api_key`')
+            self._log.warning(
+                u'You have to provide your setlist.fm API key. '
+                u'Request a key at https://www.setlist.fm/settings/apps and '
+                u'configure it as `api_key` as `api_key`'
+            )
             return
 
 
@@ -221,10 +233,13 @@ class SetlisterPlugin(BeetsPlugin):
                                 setlist_name + '.m3u'))
 
         _save_playlist(m3u_path, items)
-        self._log.info(u'Saved playlist at "{0}"'.format(m3u_path.decode('utf-8')))
+        self._log.info(
+            u'Saved playlist at "{0}"'.format(m3u_path.decode('utf-8'))
+        )
 
         if play:
-            # todo: Double check whether this is sensible ~ beets documentation (it probably isn't)
+            # todo: Double check whether this is sensible ~ beets documentation
+            #  (it probably isn't)
             subprocess.Popen(['xdg-open', m3u_path.decode('utf-8')])
 
     def find_items_in_lib(self, lib, track_names, artist_name):

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -221,7 +221,7 @@ class SetlisterPlugin(BeetsPlugin):
                                 setlist_name + '.m3u'))
 
         _save_playlist(m3u_path, items)
-        self._log.info(u'Saved playlist at "{0}"'.format(m3u_path))
+        self._log.info(u'Saved playlist at "{0}"'.format(m3u_path.decode('unicode_escape')))
 
     def find_items_in_lib(self, lib, track_names, artist_name):
         """Returns a list of items found, and list of items not found in library

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -105,7 +105,7 @@ def _save_playlist(m3u_path, items):
             f.write(item.path.decode('utf-8') + u'\n')
 
 
-
+# Reference: https://api.setlist.fm/docs/1.0/resource__1.0_search_setlists.html
 SETLISTFM_ENDPOINT = 'https://api.setlist.fm/rest/1.0/search/setlists'
 
 def _get_setlist(session, artist_name, date=None):

--- a/beetsplug/setlister.py
+++ b/beetsplug/setlister.py
@@ -69,11 +69,14 @@ def _find_item_in_lib(lib, track_name, artist_name):
     so in that case we query MB and look for the track id and query our
     lib with that.
     """
+
+    # todo: sometimes returns matches by other artists when requested artist has no matching tracks
+
     # Query the library based on the track name
     query = MatchQuery('title', track_name)
     lib_results = lib._fetch(Item, query=query)
 
-    # Maybe the provided track name isn't all too good
+    # Maybe the provided track name isn't all too good  todo: fails e.g. for Opeth - Reverie/Harlequin Forest due to mismatch in `/`
     # Search for the track on MusicBrainz, and use that info to retry our lib
     if not lib_results:
         mb_candidate = _get_mb_candidate(track_name, artist_name)

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,14 @@ Plugin for [beets](https://github.com/sampsyo/beets) to generate playlists from 
 
 
 ## Usage
-1. Clone this project, or download setlister.py, in to your configured pluginpath (e.g., `~/.beets`)
+1. Clone this project, or download [setlister.py](beetsplug/setlister.py), in to your configured pluginpath (e.g., `~/.beets`)
 2. Add `setlister` to your configured beets plugins
-3. Configure setlister to know where your playlists have to be placed
+3. Register for a setlist.fm API key [here](https://www.setlist.fm/settings/api)
+4. Configure setlister to know where your playlists have to be placed
 ```yaml
 setlister:
     playlist_dir: ~/Music/setlists
+    api_key: <YOUR API KEY HERE>
 ```
 Now you can run `$ beets setlister artist` to download the artists' latest setlist to your configured playlist directory, or specify the concert date using the `--date` option.
 
@@ -43,6 +45,4 @@ Saved playlist at "/Users/tjs/Music/setlists/alt-J at Zenith (17-02-2015).m3u"
 ## New setlist.fm API
 
 Originally, this plugin used version 0.1 of the setlist.fm API, which was discontinued from 2018 onwards. To use the new API, you have to [register for an API key here](https://www.setlist.fm/settings/api).
-
-
 

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,3 @@ Setlist: alt-J at Zenith (17-02-2015) (19 tracks)
 Saved playlist at "/Users/tjs/Music/setlists/alt-J at Zenith (17-02-2015).m3u"
 
 ```
-
-## New setlist.fm API
-
-Originally, this plugin used version 0.1 of the setlist.fm API, which was discontinued from 2018 onwards. To use the new API, you have to [register for an API key here](https://www.setlist.fm/settings/api).
-

--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,10 @@ Setlist: alt-J at Zenith (17-02-2015) (19 tracks)
 Saved playlist at "/Users/tjs/Music/setlists/alt-J at Zenith (17-02-2015).m3u"
 
 ```
+
+## New setlist.fm API
+
+Originally, this plugin used version 0.1 of the setlist.fm API, which was discontinued from 2018 onwards. To use the new API, you have to [register for an API key here](https://www.setlist.fm/settings/api).
+
+
+


### PR DESCRIPTION
Version 0.1 of the API is no longer supported and the plugin did not work.

I updated the request & response handling and added a configuration option to specify an API key (which can be requested [here](https://www.setlist.fm/settings/apps)).